### PR TITLE
Add the omitted __get_view_df

### DIFF
--- a/py2cytoscape/data/network_view.py
+++ b/py2cytoscape/data/network_view.py
@@ -76,7 +76,8 @@ class CyNetworkView(object):
 
         elif format is 'view':
             return self.__get_view_objects(views, obj_type)
-
+        elif format is 'df':
+            return _self.__get_view_df(views)
         else:
             raise ValueError('Format not supported: ' + format)
 

--- a/py2cytoscape/data/network_view.py
+++ b/py2cytoscape/data/network_view.py
@@ -115,21 +115,15 @@ class CyNetworkView(object):
         return view_dict
 
     def __get_view_df(self, views):
-        # reformat return value to simple dict
-        view_dict = {}
-
-        for view in views:
-            key = view['SUID']
-            values = view['view']
-            # Flatten the JSON
-            key_val_pair = {}
-            for entry in values:
-                vp = entry['visualProperty']
-                value = entry['value']
-                key_val_pair[vp] = value
-            view_dict[key] = key_val_pair
-
-        return view_dict
+        # view_df depends on view_dict.
+        view_dict = self.__get_view_dict(views)
+        view_df = pd.DataFrame(view_dict)
+        
+        # Transpose the DataFrame to make the visual properties as columns
+        view_df = view_df.T
+        
+        view_df.index.name = 'SUID'
+        return view_df
 
     def __get_network_view_dict(self, values):
         # reformat return value to simple dict


### PR DESCRIPTION
The methods of CyNetworkView

_get_node_views_as_dataframe()_
_get_edge_views_as_dataframe()_

do not work properly as follows:

```
df = view.get_edge_views_as_dataframe()
Traceback (most recent call last):

  File "<ipython-input-21-690d42d5378f>", line 1, in <module>
    df = view.get_edge_views_as_dataframe()

  File "C:\Anaconda\envs\py35\lib\site-packages\py2cytoscape\data\network_view.py", line 66, in get_edge_views_as_dataframe
    return self.__get_views('edges', format='df')

  File "C:\Anaconda\envs\py35\lib\site-packages\py2cytoscape\data\network_view.py", line 81, in __get_views
    raise ValueError('Format not supported: ' + format)

ValueError: Format not supported: df
```

The problem stems from the reason CyNetworkView.__get_views method does not handle the case of DataFrame format (represented as 'df') . I am wondering whether the omission was deliberate for the purpose of a development or maintenance.

